### PR TITLE
feat: provide an overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,10 @@
 
   inputs = { };
 
-  outputs = { self }: {
+  outputs = { self }: rec {
     lib = import ./.;
+    overlays.default = final: prev: {
+      nix-flake-tests = tests: lib.check {inherit tests; pkgs = final;};
+    };
   };
 }


### PR DESCRIPTION
A very simple overlay, so we can add it to flake's `pkgs` and get `callPackage` working with an input named `nix-flake-tests`.

@moduon MT-1075